### PR TITLE
adds @typedef and @returns to the list of tags checked

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,14 +1,14 @@
 /**
- * Converts TypeScript intersection types (joined with an "&") to a JSDoc type union "|" allowing the file to be 
+ * Converts TypeScript intersection types (joined with an "&") to a JSDoc type union "|" allowing the file to be
  * processed downstream. This allows you to use the amperstand "&" in your code.
- * 
+ *
  * Specifically, this creates a compatibility between Visual Studio Code's TypeScript documentation and JSDoc, as
  * Visual Studio Code's parser uses amperstands for type unions, and JSDoc uses pipes.
  * @module intersection
  */
 exports.handlers = {
     jsdocCommentFound(jsdocComment, parser) {
-        let tags = ['augments', 'extends', 'type', 'mixes', 'property', 'prop', 'param'];
+        let tags = ['augments', 'extends', 'type', 'mixes', 'property', 'prop', 'param', 'typedef', 'returns'];
         for (let tag of tags) {
             let r = new RegExp('^.+@' + tag + '\\s*\\{(?:.+&.+)\\s*\\}', 'gm');
             let match = r.exec(jsdocComment.comment);


### PR DESCRIPTION
This PR adds `@typedef` and `@returns` two to the list of tags being checked for union types. 