### PR TITLE
add a global regex to allow more than one type

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -16,7 +16,7 @@ exports.handlers = {
                 let len = match[0].length;
                 let before = jsdocComment.comment.substr(0, match.index);
                 let after = jsdocComment.comment.substr(match.index + len);
-                let replaced = match[0].replace('&', '|');
+                let replaced = match[0].replace(/&/g, '|');
                 jsdocComment.comment = before + replaced + after;
             }
         }


### PR DESCRIPTION
adding a global regex to allow more than one type to be inserted:
Example: @typedef {obj1 & obj2  & obj3}